### PR TITLE
fix new issue where resume doesn't appear on ios16

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,14 +250,14 @@
 						</header>
 						<h4>Résumé</h4>
 						<object width="100%" height="500" type="application/pdf" data="pages/resume_StephanieYan.pdf?#zoom=80&scrollbar=0&toolbar=1&navpanes=0">
-							<iframe sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="500" frameborder="0" seamless="">
+							<iframe sandbox="allow-scripts allow-same-origin allow-popups" src="pages/resume_StephanieYan.pdf?#zoom=80&scrollbar=0&toolbar=1&navpanes=0" width="100%" height="500" frameborder="0" seamless="">
 								<p>PDF cannot be displayed.</p>
 							</iframe>
 						</object>
 						<br></br>
 						<h4>CV</h4>
 						<object width="100%" height="500" type="application/pdf" data="pages/CV_StephanieYan.pdf?#zoom=80&scrollbar=0&toolbar=1&navpanes=0">
-							<iframe sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="500" frameborder="0" seamless="">
+							<iframe sandbox="allow-scripts allow-same-origin allow-popups" src="pages/resume_StephanieYan.pdf?#zoom=80&scrollbar=0&toolbar=1&navpanes=0" width="100%" height="500" frameborder="0" seamless="">
 								<p>PDF cannot be displayed.</p>
 							</iframe>
 						</object>


### PR DESCRIPTION
re-add resume link in the `iframe` section (turns out that's what ios16 is using?)